### PR TITLE
feat: hide color selection in print and add color-by-coordinate legend

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -29,7 +29,7 @@
 
 
 	<!-- Color Picker Table Goes Here -->
-	<div *ngIf="showTables">
+  <div *ngIf="showTables && !isPrintView" class="color-selection-wrapper">
 		<h2>Color Selection Table</h2>
 		<table class="color-selection">
 			<tr *ngFor="let colorOption of selectedColors; let i = index">
@@ -63,6 +63,16 @@
 	</div>
 
 	<div *ngIf="showTables">
+    
+    <div *ngIf="isPrintView">
+      <h2>Color Guide</h2>
+      <ul>
+        <li *ngFor="let entry of getColorUsageSummary()">
+          {{ entry }}
+        </li>
+      </ul>
+    </div>
+
     <h2>Color Painting Table</h2>
     <table class="color-table">
       <tr>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -17,7 +17,8 @@ export class HomeComponent {
   totalColors = 0;
   colLabels: string[] = [];
   showTables = false;
-  
+  isPrintView= false;
+
   formErrors = {
     numRows: '',
     numCols: '',
@@ -137,6 +138,7 @@ export class HomeComponent {
       Array.from({ length: this.numRows }, () =>
       Array.from({ length: this.colLabels.length }, () => "#ffffff")
     );
+    this.activeColor = this.selectedColors[0];
     console.log("colors not used: ", this.colorsNotUsed);
     console.log("cell colors: ", this.cellColors);
   }
@@ -147,12 +149,20 @@ export class HomeComponent {
   }
 
   onCellClick( i: number, j: number) {
+    if(!this.isPrintView){
     this.cellColors[i][j] = this.activeColor?.hex_value || "#ffffff";
+    }
   }
 
   // TODO: Needs refactoring to print correctly
   printPage() {
-    window.print();
+    this.isPrintView = true;
+    setTimeout(() =>{
+      window.print();
+      setTimeout(() =>{
+        this.isPrintView = false;
+      }, 1000)
+    }, 50);
   }
 
   selectColor(index: number, color: Color) {
@@ -167,6 +177,26 @@ export class HomeComponent {
     this.selectedColors[index] = color;
     this.dropdownOpen[index] = false;
   }
+
+  getColorUsageSummary(): string[] {
+    const usage: { [hex: string]: string[] } = {};
+  
+    for (let i = 0; i < this.numRows; i++) {
+      for (let j = 0; j < this.numCols; j++) {
+        const color = this.cellColors[i][j];
+        if (!usage[color]) usage[color] = [];
+        const coord = `${this.colLabels[j]}${i + 1}`;
+        usage[color].push(coord);
+      }
+    }
+  
+    return this.selectedColors.map(color => {
+      const coords = usage[color.hex_value] || [];
+      coords.sort();
+      return `${color.name} (${color.hex_value}): ${coords.join(', ')}`;
+    });
+  }
+  
 
   toggleDropdown(index: number) {
     this.dropdownOpen[index] = !this.dropdownOpen[index];

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,18 +12,20 @@
 }
 
 @media print {
+  .print-hide-color-selection {
+    display: none !important;
+  }
   * {
     color: black !important;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }
 
+
   .color-option,
   .selected-color,
   .color-table td {
-    -webkit-print-color-adjust: exact !important;
-    print-color-adjust: exact !important;
-    filter: grayscale(100%) !important;
+    background: whitesmoke !important;
   }
 
   select,


### PR DESCRIPTION
- Wrapped color selection table in a conditional div to exclude it from print view
- Added color coordinate legend for print, showing color names, hex codes, and cell coordinates
- Fixed print styles to ensure lower table cells print as blank (white) without color fill
- Added getColorUsageSummary() helper method for generating coordinate lists
- Updated printPage() logic for cleaner DOM rendering in print view